### PR TITLE
use subprocess to restart

### DIFF
--- a/pyra/__init__.py
+++ b/pyra/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # standard imports
 import os
+import subprocess
 import sys
 import threading
 from typing import Union
@@ -143,9 +144,10 @@ def stop(exit_code: Union[int, str] = 0, restart: bool = False):
         if '--nolaunch' not in args:  # don't launch the browser again
             args += ['--nolaunch']  # also os.execv requires at least one argument
 
-        os.execv(sys.executable, args)
-        # alternative to os.execv() ... requires `import subprocess`
-        # subprocess.Popen(args=args, cwd=os.getcwd())
+        # os.execv(sys.executable, args)
+        # `os.execv` is more desirable, but is not working correctly
+        # flask app does not respond to requests after restarting
+        # alternative to os.execv()
+        subprocess.Popen(args=args, cwd=os.getcwd())
 
-    else:
-        sys.exit(exit_code)  # this isn't really needed, the code will terminate just after this moment either way
+    sys.exit(exit_code)

--- a/retroarcher.py
+++ b/retroarcher.py
@@ -239,8 +239,6 @@ def wait():
                 log.error('Unknown signal. Shutting down...')
                 pyra.stop()
 
-            pyra.SIGNAL = None
-
             break
 
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- use `subprocess` to handle restart signal

`os.execv` is more desirable to use for restarting; however flask app is not responding to requests after restarting

This works for the following situations.
- [x] running from source
- [x] running pyinstaller bundle (from command line)
- [ ] running pyinstaller bundle (double clicking binary)
  - I don't know if it's possible to handle this situation as the window is closed once the original process is finished.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
