### PR TITLE
qodana: use repository dispatch

### DIFF
--- a/.github/workflows/ci-qodana.yml
+++ b/.github/workflows/ci-qodana.yml
@@ -6,24 +6,22 @@
 name: Qodana
 
 on:
-  # pull_request_target will not work unless workflow exists in target already, but required for token access
-  pull_request_target:
+  pull_request:
     branches: [master, nightly]
     types: [opened, synchronize, reopened]
   push:
     branches: [master, nightly]
+  repository_dispatch:
+    types: [qodana-notify]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+# concurrency is handled in the dispatch-qodana workflow
 
 jobs:
-  check_qodana_files:
-    name: Check Qodana Files
+  qodana_initial_check:
+    name: Qodana Initial Check
+    if: ${{ github.event_name != 'repository_dispatch' }}
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write  # required to add PR comment
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,26 +33,29 @@ jobs:
           if [ "${{ github.event_name }}" == "push" ]
           then
             echo "This is a PUSH event"
+            checkout_repo=${{ github.event.repository.full_name }}
+            checkout_ref=${{ github.ref }}
             # use the branch name
             destination=${{ github.ref_name }}
             target=${{ github.ref_name }}
           else
             echo "This is a PR event"
+            checkout_repo=${{ github.event.pull_request.head.repo.full_name }}
+            checkout_ref=${{ github.event.pull_request.head.ref }}
             # use the PR number
             destination=${{ github.event.pull_request.number }}
             target=${{ github.event.pull_request.base.ref }}
           fi
 
+          echo "checkout_repo=$checkout_repo" >> $GITHUB_OUTPUT
+          echo "checkout_ref=$checkout_ref" >> $GITHUB_OUTPUT
           echo "destination=$destination" >> $GITHUB_OUTPUT
           echo "target=$target" >> $GITHUB_OUTPUT
 
           # prepare urls
           base=https://${{ github.repository_owner }}.github.io
           report_url=${base}/qodana-reports/${{ github.event.repository.name }}/${destination}
-          workflow_url_a=https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}
-          workflow_url=${workflow_url_a}/actions/runs/${{ github.run_id }}
           echo "report_url=$report_url" >> $GITHUB_OUTPUT
-          echo "workflow_url=$workflow_url" >> $GITHUB_OUTPUT
 
           # build matrix
           files=$(find . -type f -iname "qodana*.yaml")
@@ -90,142 +91,80 @@ jobs:
 
           echo "reports_markdown=$REPORTS_MARKDOWN" >> $GITHUB_OUTPUT
 
-      - name: Setup PR comment
-        if: ${{ startsWith(github.event_name, 'pull_request') && steps.prepare.outputs.files != '' }}
-        uses: mshick/add-pr-comment@v2
+      - name: Setup client payload
+        id: client_payload
+        if: ${{ steps.prepare.outputs.files != '' }}
+        run: |
+          client_payload=$(echo '{
+            "checkout_repo": "'"${{ steps.prepare.outputs.checkout_repo }}"'",
+            "checkout_ref": "'"${{ steps.prepare.outputs.checkout_ref }}"'",
+            "destination": "'"${{ steps.prepare.outputs.destination }}"'",
+            "target": "'"${{ steps.prepare.outputs.target }}"'",
+            "files": "'"${{ steps.prepare.outputs.files }}"'",
+            "reports_markdown": "'"${{ steps.prepare.outputs.reports_markdown }}"'",
+            "github": ${{ toJson(github) }},
+            "matrix": ${{ toJson(steps.prepare.outputs.matrix) }}
+          }' | jq -c .)
+
+          echo $client_payload
+          echo $client_payload | jq .
+          echo "client_payload=$client_payload" >> $GITHUB_OUTPUT
+
+      - name: Repository Dispatch
+        if: ${{ steps.prepare.outputs.files != '' }}
+        uses: peter-evans/repository-dispatch@v2.1.1
         with:
-          repo-token: ${{ secrets.GH_BOT_TOKEN }}
-          message: |
-            :warning: **Qodana is checking this PR** :warning:
-            Live results available [here](${{ steps.prepare.outputs.workflow_url }})
-
-    outputs:
-      destination: ${{ steps.prepare.outputs.destination }}
-      files: ${{ steps.prepare.outputs.files }}
-      matrix: ${{ steps.prepare.outputs.matrix }}
-      reports_markdown: ${{ steps.prepare.outputs.reports_markdown }}
-      target: ${{ steps.prepare.outputs.target }}
-      workflow_url: ${{ steps.prepare.outputs.workflow_url }}
-
-  qodana:
-    needs: [check_qodana_files]
-    if: ${{ needs.check_qodana_files.outputs.files }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.check_qodana_files.outputs.matrix) }}
-      max-parallel: 1
-    name: Qodana-${{ matrix.language }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Checkout Qodana/gh-pages repo
-        uses: actions/checkout@v3
-        with:
+          token: ${{ secrets.GH_BOT_TOKEN }}
           repository: ${{ github.repository_owner }}/qodana-reports
-          ref: gh-pages
-          path: gh-pages
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of the personal token
-          fetch-depth: 0  # otherwise, will fail to push refs to dest repo
+          event-type: qodana-scan
+          client-payload: ${{ steps.client_payload.outputs.client_payload }}
 
-      - name: Get baseline
-        id: baseline
-        run: |
-          base_url=https://app.lizardbyte.dev/qodana-reports/${{ github.event.repository.name }}/${{ matrix.language }}
-          baseline_file=qodana.sarif.json
-
-          # download baseline with wget and without failing
-          wget -q ${base_url}/results/${{ needs.check_qodana_files.outputs.target }}/${baseline_file} || true
-
-          # check if file exists
-          if [ -f ${baseline_file} ]
-          then
-              echo "baseline exists"
-              echo "baseline_args=--baseline,qodana.sarif.json" >> $GITHUB_OUTPUT
-          else
-              echo "baseline does not exist"
-              echo "baseline_args=" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Rename Qodana config file
-        run: |
-          # rename the file
-          if [ "${{ matrix.file }}" != "./qodana.yaml" ]
-          then
-            mv -f ${{ matrix.file }} ./qodana.yaml
-          fi
-
-      - name: Qodana
-        id: qodana
-        uses: JetBrains/qodana-action@v2022.3.4
-        with:
-          additional-cache-hash: ${{ matrix.language }}
-          args: '--print-problems,${{ steps.baseline.outputs.baseline_args }}'
-          pr-mode: false
-          upload-result: true
-          use-caches: true
-
-      - name: Prepare gh-pages
-        id: pages
-        if: always()
-        run: |
-          # set the output directory
-          output_dir_a=./gh-pages/${{ github.event.repository.name }}/
-          output_dir=${output_dir_a}/${{ needs.check_qodana_files.outputs.destination }}/${{ matrix.language }}
-          mkdir -p $output_dir
-
-          # empty contents
-          rm -f -r $output_dir/*
-
-          # copy qodana results
-          cp -f -r ${{ runner.temp }}/qodana/results/report/. $output_dir/
-
-      - name: Deploy to gh-pages
-        id: deploy
-        if: ${{ steps.pages.conclusion == 'success' }}
-        uses: actions-js/push@v1.4
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          author_email: ${{ secrets.GH_BOT_EMAIL }}
-          author_name: ${{ secrets.GH_BOT_NAME }}
-          repository: ${{ secrets.GH_ORG_NAME }}/qodana-reports
-          directory: gh-pages
-          branch: gh-pages
-          force: false
-          message: >-
-            update
-            ${{ github.event.repository.name }}
-            ${{ needs.check_qodana_files.outputs.destination }}
-            ${{ matrix.language }}
-
-  notify:
-    name: Notify
-    needs: [check_qodana_files, qodana]
-    if: >-
-      startsWith(github.event_name, 'pull_request') &&
-      needs.check_qodana_files.outputs.files &&
-      needs.qodana.result
+  qodana_notify:
+    name: Qodana Notify
+    if: ${{ github.event_name == 'repository_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write  # required to add PR comment
-
     steps:
-      - name: Update PR comment
+
+      - name: Initial PR comment
+        if: ${{ github.event.client_payload.final == 'false' }}
         uses: mshick/add-pr-comment@v2
         with:
+          issue: ${{ github.event.client_payload.pull_request_number }}
           repo-token: ${{ secrets.GH_BOT_TOKEN }}
-          status: ${{ needs.qodana.result }}
+          message: |
+            :warning: **Qodana is checking this PR** :warning:
+            Live results available [here](${{ github.event.client_payload.workflow_url }})
+
+      - name: Final PR comment
+        if: ${{ github.event.client_payload.final != 'false' }}
+        uses: mshick/add-pr-comment@v2
+        with:
+          issue: ${{ github.event.client_payload.pull_request_number }}
+          repo-token: ${{ secrets.GH_BOT_TOKEN }}
+          status: ${{ github.event.client_payload.status }}
           message-failure: |
             :warning: **Qodana: failure**
 
-            [Logs](${{ steps.prepare.outputs.workflow_url }})
+            [Logs](${{ github.event.client_payload.workflow_url }})
 
-            Reports: ${{ needs.check_qodana_files.outputs.reports_markdown }}
+            Reports: ${{ github.event.client_payload.reports_markdown }}
+
+            :information_source: It may take a few minutes for the reports to be live. Check status
+            [here](https://github.com/LizardByte/qodana-reports/actions/workflows/pages/pages-build-deployment).
+
           message-success: |
             :white_check_mark: **Qodana: success**
 
-            Reports: ${{ needs.check_qodana_files.outputs.reports_markdown }}
+            Reports: ${{ github.event.client_payload.reports_markdown }}
+
+            :information_source: It may take a few minutes for the reports to be live. Check status
+            [here](https://github.com/LizardByte/qodana-reports/actions/workflows/pages/pages-build-deployment).
+
+      - name: Fail workflow
+        if: ${{ github.event.client_payload.status != 'success' }}
+        run: |
+          echo "Qodana failed"
+          echo "See the logs at ${{ github.event.client_payload.workflow_url }}"
+          exit 1


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use repository dispatch for qodana to call workflow from `qodana-reports` repo.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
