### PR TITLE
fix(helpers): properly check public status of IPv6 addresses

### DIFF
--- a/pyra/helpers.py
+++ b/pyra/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # standard imports
 import datetime
+import ipaddress
 import logging
 import re
 import os
@@ -165,12 +166,16 @@ def is_public_ip(host: str) -> bool:
     False
     """
     ip = is_valid_ip(address=get_ip(host=host))
-    if ip and ip.iptype() == 'PUBLIC':
-        return True
-    return False
+
+    # use built in ipaddress module to check if address is private since IPy does not work IPv6 addresses
+    if ip:
+        ip_obj = ipaddress.ip_address(address=ip)
+        return not ip_obj.is_private
+    else:
+        return False
 
 
-def get_ip(host: str) -> str:
+def get_ip(host: str) -> Optional[str]:
     """
     Get IP address from host name.
 
@@ -184,7 +189,7 @@ def get_ip(host: str) -> str:
     Returns
     -------
     str
-        IP address of host name.
+        IP address of host name if it is a valid ip address, otherwise ``None``.
 
     Examples
     --------
@@ -201,6 +206,7 @@ def get_ip(host: str) -> str:
             ip_address = socket.getaddrinfo(host=host, port=None)[0][4][0]
         except Exception:
             log.error(f"IP Checker :: Bad IP or hostname provided: {host}.")
+            return None
         else:
             log.debug(f"IP Checker :: Resolved {host} to {ip_address}.")
             return ip_address

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -27,17 +27,31 @@ def test_get_logger():
 
 
 def test_is_public_ip():
-    """Test if ip address is pubic, then tests if ip address is private"""
-    # test public ip
-    address = 'www.google.com'
-    ip = helpers.get_ip(host=address)
-    public_ip = helpers.is_public_ip(host=ip)
-    assert public_ip
+    """Test if ip address is pubic or private"""
+    # test public ips
+    public_addresses = [
+        'www.google.com',
+        '8.8.8.8',
+        '8.8.4.4',
+        '2001:4860:4860::8888',
+        '2001:4860:4860::8844',
+    ]
 
-    # test private ip
-    ip = '192.168.1.1'
-    public_ip = helpers.is_public_ip(host=ip)
-    assert not public_ip
+    private_addresses = [
+        '192.168.1.1'
+    ]
+
+    address_types = [public_addresses, private_addresses]
+
+    for address_type in address_types:
+        for address in address_type:
+            ip = helpers.get_ip(host=address)
+            public_ip = helpers.is_public_ip(host=ip)
+
+            if address_type == public_addresses:
+                assert public_ip
+            else:
+                assert not public_ip
 
 
 def test_get_ip():


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR fixes an issue where addresses such as `www.google.com` may return an IPv6 address which did not return as private when connected to an IPv6 network.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
