### PR TITLE
fix: add exception handling to get amd gpu usage

### DIFF
--- a/pyra/hardware.py
+++ b/pyra/hardware.py
@@ -64,7 +64,7 @@ try:
 except ModuleNotFoundError:
     pyamdgpu = False
     try:
-        from pyadl import ADLManager
+        from pyadl import ADLManager, ADLError
     except Exception:  # cannot import `ADLError` from `pyadl.pyadl`
         amd_gpus = range(0)  # no amd gpus found
     else:
@@ -151,7 +151,10 @@ def update_gpu():
                     gpu_load = min(100, gpu.query_load())  # max of 100
                 else:
                     name = f'{gpu.adapterName.decode("utf-8")}-{gpu.adapterIndex}'  # adapterName is bytes so decode it
-                    gpu_load = min(100, gpu.getCurrentUsage())  # max of 100
+                    try:
+                        gpu_load = min(100, gpu.getCurrentUsage())  # max of 100
+                    except ADLError:
+                        gpu_load = None
 
             if initialized and name:
                 try:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When first starting RetroArcher, the `getCurrentUsage()` method, may return an error initially. This PR adds a try/except block around it.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
