### PR TITLE
build(deps): bump codecov/codecov-action from v3 to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -119,15 +119,13 @@ jobs:
             --cov=pyra \
             tests
 
-      - name: Upload coverage to Codecov
-        uses: Wandalen/wretry.action@v1
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
         with:
-          action: codecov/codecov-action@v3
-          attempt_delay: 10000
-          attempt_limit: 10
-          with: |
-            fail_ci_if_error: true
-            flags: ${{ runner.os }}-${{ matrix.architecture }}
+          fail_ci_if_error: true
+          flags: "${{ runner.os }}-${{ matrix.architecture }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
       - name: Create/Update GitHub Release
         if: ${{ needs.setup_release.outputs.publish_release == 'true' }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
codecov v3 is broken, need to update to v4


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
